### PR TITLE
[codex] handle empty daily pv in short-link list

### DIFF
--- a/console/dwz/dwz.js
+++ b/console/dwz/dwz.js
@@ -238,8 +238,9 @@ function getDwzList(pageNum) {
                     }
                     
                     // 今天访问量
-                    var dwz_today_pv = JSON.parse(res.dwzList[i].dwz_today_pv.toString()).pv;
-                    var dwz_today_date = JSON.parse(res.dwzList[i].dwz_today_pv.toString()).date;
+                    var dwz_today_data = res.dwzList[i].dwz_today_pv ? JSON.parse(res.dwzList[i].dwz_today_pv.toString()) : {pv: 0, date: 0};
+                    var dwz_today_pv = dwz_today_data.pv;
+                    var dwz_today_date = dwz_today_data.date;
                     
                     // 获取日期
                     const today = new Date();
@@ -852,8 +853,9 @@ function checkDwz() {
                         }
                         
                         // 今天访问量
-                        var dwz_today_pv = JSON.parse(res.dwzList[i].dwz_today_pv.toString()).pv;
-                        var dwz_today_date = JSON.parse(res.dwzList[i].dwz_today_pv.toString()).date;
+                        var dwz_today_data = res.dwzList[i].dwz_today_pv ? JSON.parse(res.dwzList[i].dwz_today_pv.toString()) : {pv: 0, date: 0};
+                        var dwz_today_pv = dwz_today_data.pv;
+                        var dwz_today_date = dwz_today_data.date;
                         
                         // 获取日期
                         const today = new Date();


### PR DESCRIPTION
## Summary
- guard short-link list rendering when `dwz_today_pv` is empty
- reuse the parsed daily pv object instead of parsing the same JSON twice

## Root cause
API-created short links can return `dwz_today_pv` as `null`. The list renderer called `.toString()` before parsing it, which stops rendering and prevents those rows from showing in the dashboard.

## Validation
- `node --check console/dwz/dwz.js`
- smoke checked the `null` fallback and normal JSON parsing path with Node
- `git diff --check`

Fixes #24